### PR TITLE
Escape HTML entities before saving and rendering - fix XSS

### DIFF
--- a/papermerge/contrib/admin/static/admin/js/papermerge.debug.js
+++ b/papermerge/contrib/admin/static/admin/js/papermerge.debug.js
@@ -19615,6 +19615,19 @@ class Metadata extends backbone__WEBPACK_IMPORTED_MODULE_1__["Model"] {
     return false;
   }
 
+  // encode strings to make html-safe
+  escape(chars) {
+    return chars.replace(/[&<>'"]/g, function(tag) {
+      return {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        "'": '&#39;',
+        '"': '&quot;'
+      }[tag];
+    });
+  }
+
   urlRoot() {
     return `/metadata/node/${this.doc_id}`;
   }
@@ -19657,7 +19670,7 @@ class Metadata extends backbone__WEBPACK_IMPORTED_MODULE_1__["Model"] {
         dict = {};
 
     if (model && attr) {
-      dict[attr] = value;
+      dict[attr] = this.escape(value);
       model.set(dict);
     }
   }

--- a/papermerge/core/views/metadata.py
+++ b/papermerge/core/views/metadata.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import html
 
 from django.contrib.auth.decorators import login_required
 from django.http import (
@@ -73,6 +74,15 @@ def metadata(request, model, id):
     )
 
 
+def _escape_html_entities(kvstore_key):
+    """
+    Convert characters to html-safe strings, if key is a string.
+    """
+    if isinstance(kvstore_key, str):
+        return html.escape(kvstore_key)
+    return kvstore_key
+
+
 def _sanitize_kvstore_list(kvstore_list):
     """
     Creates a new dictionay only with allowed keys.
@@ -89,7 +99,7 @@ def _sanitize_kvstore_list(kvstore_list):
 
     for item in kvstore_list:
         sanitized_kvstore_item = {
-            allowed_key: item.get(allowed_key, None)
+            allowed_key: _escape_html_entities(item.get(allowed_key, None))
             for allowed_key in allowed_keys
             if allowed_key in item.keys()
         }


### PR DESCRIPTION
### 📊 Metadata *

`Papermerge `is an open source document management system (DMS) primarily designed for archiving and retrieving your digital documents. Instead of having piles of paper documents all over your desk, office or drawers - you can quickly scan them and configure your scanner to directly upload to Papermerge DMS.. This package is vulnerable for (XSS).

`https://github.com/ciur/papermerge https://pypi.org/project/papermerge/`

#### Bounty URL: https://www.huntr.dev/bounties/1-pip-papermerge/

### ⚙️ Description *

Cross-Site Scripting (XSS) attacks are a type of injection, in which malicious scripts are injected into otherwise benign and trusted websites. XSS attacks occur when an attacker uses a web application to send malicious code, generally in the form of a browser side script, to a different end user. Flaws that allow these attacks to succeed are quite widespread and occur anywhere a web application uses input from a user within the output it generates without validating or encoding it.

### 💻 Technical Description *

Cross-Site Scripting (XSS) attacks are mitigated by sanitizing the user inputs before rendering, thereby preventing malicious execution.

### 🐛 Proof of Concept (PoC) *

1. clone https://github.com/ciur/papermerge or use demo https://demo.papermerge.com/
2. add jscode in meta form. Payload used : "><img src=x onerror=alert(137)>

### 🔥 Proof of Fix (PoF) *

Before: 
`https://drive.google.com/file/d/1AovUz4yG46RRVCRlohd1-YyTlO_edEKg/view?usp=sharing`

After:
![image](https://user-images.githubusercontent.com/64132745/107263892-50d1c580-6a68-11eb-9a52-47c1d60b55eb.png)

### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1490/files
